### PR TITLE
Implement SendQueue data structure for relaying messages.

### DIFF
--- a/go/apps/mixnet/conn.go
+++ b/go/apps/mixnet/conn.go
@@ -23,8 +23,12 @@ import (
 )
 
 const (
-	CellBytes   = 1 << 10 // Length of a cell
-	MaxMsgBytes = 1 << 16 // Maximum length of a message
+
+	// CellBytes specifies the length of a cell.
+	CellBytes = 1 << 10
+
+	// MaxMsgBytes specifies the maximum length of a message.
+	MaxMsgBytes = 1 << 16
 )
 
 const (
@@ -33,16 +37,17 @@ const (
 	relayCell
 )
 
-var errCellLength error = errors.New("incorrect cell length")
-var errBadCellType error = errors.New("unrecognized cell type")
-var errBadDirective error = errors.New("received bad directive")
-var errMsgLength error = errors.New("message too long")
+var errCellLength = errors.New("incorrect cell length")
+var errBadCellType = errors.New("unrecognized cell type")
+var errBadDirective = errors.New("received bad directive")
+var errMsgLength = errors.New("message too long")
 
 // Conn implements the net.Conn interface. The read and write operations are
 // overloaded to check that only cells are sent between agents in the mixnet
 // protocol.
 type Conn struct {
 	net.Conn
+	id uint64 // Serial identifier of connection in a given context.
 }
 
 // Read a cell from the channel. If len(msg) != CellBytes, return an error.
@@ -69,10 +74,10 @@ func (c *Conn) Write(msg []byte) (n int, err error) {
 	return n, nil
 }
 
-// Serialize and pad a directive to the length of a cell and send it to the
-// router. A directive is signaled to the receiver by the first byte of the
-// cell. The next 8 bytes encodes the length of of the serialized protocol
-// buffer. If the buffer doesn't fit in a cell, then throw an error.
+// SendDirective serializes and pads a directive to the length of a cell and
+// sends it to the router. A directive is signaled to the receiver by the first
+// byte of the cell. The next 8 bytes encodes the length of of the serialized
+// protocol buffer. If the buffer doesn't fit in a cell, then throw an error.
 func SendDirective(c net.Conn, d *Directive) (int, error) {
 	db, err := proto.Marshal(d)
 	if err != nil {

--- a/go/apps/mixnet/mixnet.pb.go
+++ b/go/apps/mixnet/mixnet.pb.go
@@ -10,6 +10,7 @@ It is generated from these files:
 
 It has these top-level messages:
 	Directive
+	Queueable
 */
 package mixnet
 
@@ -94,6 +95,49 @@ func (m *Directive) GetError() string {
 		return *m.Error
 	}
 	return ""
+}
+
+// Protocol buffer for a message or directive in a send queue.
+type Queueable struct {
+	// Serial identifier of the sender.
+	Id *uint64 `protobuf:"varint,1,req,name=id" json:"id,omitempty"`
+	// If the connection needs to be set up, specify the address the host.
+	Addr             *string    `protobuf:"bytes,2,opt,name=addr" json:"addr,omitempty"`
+	Dir              *Directive `protobuf:"bytes,3,opt,name=dir" json:"dir,omitempty"`
+	Msg              []byte     `protobuf:"bytes,4,opt,name=msg" json:"msg,omitempty"`
+	XXX_unrecognized []byte     `json:"-"`
+}
+
+func (m *Queueable) Reset()         { *m = Queueable{} }
+func (m *Queueable) String() string { return proto.CompactTextString(m) }
+func (*Queueable) ProtoMessage()    {}
+
+func (m *Queueable) GetId() uint64 {
+	if m != nil && m.Id != nil {
+		return *m.Id
+	}
+	return 0
+}
+
+func (m *Queueable) GetAddr() string {
+	if m != nil && m.Addr != nil {
+		return *m.Addr
+	}
+	return ""
+}
+
+func (m *Queueable) GetDir() *Directive {
+	if m != nil {
+		return m.Dir
+	}
+	return nil
+}
+
+func (m *Queueable) GetMsg() []byte {
+	if m != nil {
+		return m.Msg
+	}
+	return nil
 }
 
 func init() {

--- a/go/apps/mixnet/mixnet.proto
+++ b/go/apps/mixnet/mixnet.proto
@@ -33,3 +33,15 @@ message Directive {
   // ERROR or FATAL, an error message.
   optional string error = 3;
 }
+
+// Protocol buffer for a message or directive in a send queue.
+message Queueable {
+  // Serial identifier of the sender.
+  required uint64 id = 1;
+
+  // If the connection needs to be set up, specify the address the host.
+  optional string addr = 2;
+
+  optional Directive dir = 3;
+  optional bytes msg = 4;
+}

--- a/go/apps/mixnet/queue.go
+++ b/go/apps/mixnet/queue.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2015, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mixnet
+
+import (
+	"container/list"
+	"errors"
+	"math/rand"
+	"net"
+
+	"github.com/golang/glog"
+)
+
+type sendQueueError struct {
+	id uint64 // Serial identifier of sender to which error pertains.
+	error
+}
+
+// The SendQueue structure maps a serial identifier corresponding to a sender
+// (in the router context) to a destination. It also maintains a message buffer
+// for each sender. Once there messages ready on enough buffers, a batch of
+// messages are transmitted simultaneously.
+type SendQueue struct {
+	batchSize int // Number of messages to transmit in a roud.
+	ct        int // Current number of buffers with messages ready.
+
+	network string // Network protocol, e.g. "tcp".
+
+	nextAddr   map[uint64]string     // Address of destination.
+	nextConn   map[uint64]net.Conn   // Connection to destination.
+	sendBuffer map[uint64]*list.List // Message buffer of sender.
+
+	queue chan Queueable      // Channel for queueing messages/directives.
+	err   chan sendQueueError // Channel for handling errors.
+}
+
+// NewSendQueue creates a new SendQueue structure.
+func NewSendQueue(network string, batchSize int) (sq *SendQueue) {
+	sq = new(SendQueue)
+	sq.batchSize = batchSize
+	sq.network = network
+
+	sq.nextAddr = make(map[uint64]string)
+	sq.nextConn = make(map[uint64]net.Conn)
+	sq.sendBuffer = make(map[uint64]*list.List)
+
+	sq.queue = make(chan Queueable)
+	sq.err = make(chan sendQueueError)
+	return sq
+}
+
+// Enqueue adds a queueable object, such as a message or directive, to the
+// send queue.
+func (sq *SendQueue) Enqueue(q *Queueable) {
+	sq.queue <- *q
+}
+
+// DoSendQueue adds messages to a queue and transmits messages in batches.
+// Typically a message is a cell, but when the calling router is an exit point,
+// the message length is arbitrary. A batch is transmitted when there are
+// messages on batchSize distinct sender channels.
+func (sq *SendQueue) DoSendQueue(kill <-chan bool) {
+	for {
+		select {
+		case <-kill:
+			for _, c := range sq.nextConn {
+				c.Close()
+			}
+			return
+
+		case q := <-sq.queue:
+			// Set the next-hop address. We don't allow the destination address
+			// or connection to be overwritten in order to avoid accumulating
+			// stale connections on routers.
+			if _, def := sq.nextAddr[*q.Id]; !def && q.Addr != nil {
+				sq.nextAddr[*q.Id] = *q.Addr
+			}
+
+			if q.Dir != nil {
+				sq.err <- sendQueueError{*q.Id,
+					errors.New("directives not implemented")}
+
+			} else if _, def := sq.nextAddr[*q.Id]; !def && q.Msg != nil {
+				sq.err <- sendQueueError{*q.Id,
+					errors.New("request to send message without a destination")}
+
+			} else {
+
+				// Create a send buffer for the sender ID if it doesn't exist.
+				if _, def := sq.sendBuffer[*q.Id]; !def {
+					sq.sendBuffer[*q.Id] = list.New()
+				}
+				buf := sq.sendBuffer[*q.Id]
+
+				// The buffer was empty but now has a message ready; increment
+				// the counter.
+				if buf.Len() == 0 {
+					sq.ct++
+				}
+
+				// Add message to send buffer.
+				buf.PushBack(q.Msg)
+			}
+
+			// Transmit the message batch if it is full.
+			if sq.ct == sq.batchSize {
+				sq.dequeue()
+			}
+		}
+	}
+}
+
+// DoSendQueueErrorHandler handles errors produced by DoSendQueue. When this
+// is fully fleshed out, it will enqueue into the response queue a Directive
+// containing an error message. For now, just print out the error.
+func (sq *SendQueue) DoSendQueueErrorHandler(kill <-chan bool) {
+	for {
+		select {
+		case <-kill:
+			return
+		case err := <-sq.err:
+			glog.Errorf("send queue (%d): %s\n", err.id, err.Error())
+		}
+	}
+}
+
+// dequeue sends one message from each send buffer for each serial ID in a
+// random order. This is called by DoSendQueue and is not safe to call directly
+// elsewhere.
+func (sq *SendQueue) dequeue() {
+
+	// Shuffle the serial IDs.
+	order := rand.Perm(int(sq.ct)) // TODO(cjpatton) Use tao.GetRandomBytes().
+	ids := make([]uint64, sq.ct)
+	i := 0
+	for id := range sq.sendBuffer {
+		ids[order[i]] = id
+		i++
+	}
+
+	// Issue a sendWorker thread for each message to be sent.
+	ch := make(chan senderResult)
+	for _, id := range ids {
+		addr := sq.nextAddr[id]
+		msg := sq.sendBuffer[id].Front().Value.([]byte)
+		c, def := sq.nextConn[id]
+		go senderWorker(network, addr, id, msg, c, def, ch, sq.err)
+	}
+
+	// Wait for workers to finish.
+	for _ = range ids {
+		res := <-ch
+		if res.c != nil {
+			// Save the connection.
+			sq.nextConn[res.id] = res.c
+
+			// Pop the message from the buffer and decrement the counter
+			// if the buffer is empty.
+			buf := sq.sendBuffer[res.id]
+			buf.Remove(buf.Front())
+			if buf.Len() == 0 {
+				sq.ct--
+			}
+		}
+	}
+}
+
+type senderResult struct {
+	c  net.Conn
+	id uint64
+}
+
+func senderWorker(network, addr string, id uint64, msg []byte, c net.Conn, def bool,
+	res chan<- senderResult, err chan<- sendQueueError) {
+	var e error
+
+	// Wait to connect until the queue is dequeued in order to prevent
+	// an observer from correlating an incoming cell with the handshake
+	// with the destination server.
+	if !def {
+		c, e = net.Dial(network, addr) // TODO(cjpatton) timeout.
+		if e != nil {
+			err <- sendQueueError{id, e}
+			res <- senderResult{nil, id}
+			return
+		}
+	}
+
+	// Send the message.
+	if _, e := c.Write(msg); e != nil {
+		err <- sendQueueError{id, e}
+		res <- senderResult{nil, id}
+		return
+	}
+
+	res <- senderResult{c, id}
+}

--- a/go/apps/mixnet/queue_test.go
+++ b/go/apps/mixnet/queue_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2015, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License0.
+
+package mixnet
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// A dummy server that accepts ct connections and waits for a message
+// from each client.
+func runDummyServer(ct int, ch chan<- testResult) {
+	l, err := net.Listen(network, dstAddr)
+	if err != nil {
+		ch <- testResult{err, []byte{}}
+		return
+	}
+	defer l.Close()
+
+	done := make(chan bool)
+	for i := 0; i < ct; i++ {
+		c, err := l.Accept()
+		if err != nil {
+			ch <- testResult{err, []byte{}}
+			return
+		}
+		defer c.Close()
+
+		go func() {
+			buff := make([]byte, CellBytes*10)
+			bytes, err := c.Read(buff)
+			if err != nil {
+				ch <- testResult{err, []byte{}}
+				done <- true
+				return
+			}
+
+			ch <- testResult{nil, buff[:bytes]}
+			done <- true
+		}()
+	}
+
+	for i := 0; i < ct; i++ {
+		<-done
+	}
+}
+
+// Enqueue a bunch of messages and then dequeue them.
+func TestSendQueue(t *testing.T) {
+	batchSize := 10
+	sq := NewSendQueue(network, batchSize)
+	kill := make(chan bool)
+	done := make(chan bool)
+	dstCh := make(chan testResult)
+
+	go runDummyServer(batchSize, dstCh)
+
+	go func() {
+		sq.DoSendQueue(kill)
+		done <- true
+	}()
+
+	go func() {
+		sq.DoSendQueueErrorHandler(kill)
+		done <- true
+	}()
+
+	// Enqueue some messages.
+	for i := 0; i < batchSize; i++ {
+		q := new(Queueable)
+		q.Id = proto.Uint64(uint64(i))
+		q.Addr = proto.String(dstAddr)
+		q.Msg = []byte(
+			fmt.Sprintf("I am anonymous, but my ID is %d.", i))
+		sq.Enqueue(q)
+	}
+
+	// Read results from destination server.
+	for i := 0; i < batchSize; i++ {
+		res := <-dstCh
+		if res.err != nil {
+			t.Error(res.err)
+		} else {
+			t.Log(string(res.msg))
+		}
+	}
+
+	kill <- true
+	kill <- true
+
+	<-done
+	<-done
+}


### PR DESCRIPTION
SendQueue associates a serial identifier (which identifies a sender in the router's context) with a TCP connection to a destination. It stores a message buffer for each serial ID and tranmits a batch of messages when some number of buffers (called the batch size) have a message ready. The TCP handshake is delayed until send time so that an observer can't correlate incoming traffic with the handshake.