### PR TITLE
Integrate SendQueue into RouterContext. 

### DIFF
--- a/go/apps/mixnet/mixnet_router/mixnet_router.go
+++ b/go/apps/mixnet/mixnet_router/mixnet_router.go
@@ -57,6 +57,7 @@ func serveMixnetClients(hp *mixnet.RouterContext) error {
 var serverAddr = flag.String("addr", "localhost:8123", "Address and port for Tao server.")
 var serverNetwork = flag.String("network", "tcp", "Network protocol for Tao server.")
 var configPath = flag.String("config", "tao.config", "Path to domain configuration file.")
+var batchSize = flag.Int("batch", 2, "Number of senders in a batch.")
 
 // x509 identity of the mixnet router.
 var x509Identity pkix.Name = pkix.Name{
@@ -66,7 +67,7 @@ var x509Identity pkix.Name = pkix.Name{
 
 func main() {
 	flag.Parse()
-	hp, err := mixnet.NewRouterContext(*configPath, *serverNetwork, *serverAddr,
+	hp, err := mixnet.NewRouterContext(*configPath, *serverNetwork, *serverAddr, *batchSize,
 		&x509Identity, tao.Parent())
 	if err != nil {
 		glog.Errorf("failed to configure server: %s", err)

--- a/go/apps/mixnet/queue_test.go
+++ b/go/apps/mixnet/queue_test.go
@@ -64,9 +64,13 @@ func runDummyServer(clientCt, msgCt int, ch chan<- testResult) {
 // Test SendQueue by enqueueing a bunch of messages and dequeueing them.
 // Test multiple rounds.
 func TestSendQueue(t *testing.T) {
-	clientCt := 3
-	msgCt := 2
-	sq := NewSendQueue(network, clientCt)
+
+	// batchSize must divide clientCt; otherwise the sendQueue will block forever.
+	batchSize := 2
+	clientCt := 4
+	msgCt := 3
+
+	sq := NewSendQueue(network, batchSize)
 	kill := make(chan bool)
 	done := make(chan bool)
 	dstCh := make(chan testResult)

--- a/go/apps/mixnet/queue_test.go
+++ b/go/apps/mixnet/queue_test.go
@@ -40,7 +40,7 @@ func runDummyServer(clientCt, msgCt int, ch chan<- testResult) {
 			return
 		}
 
-		go func() {
+		go func(c net.Conn) {
 			defer c.Close()
 			buff := make([]byte, CellBytes*10)
 			for j := 0; j < msgCt; j++ {
@@ -48,12 +48,11 @@ func runDummyServer(clientCt, msgCt int, ch chan<- testResult) {
 				if err != nil {
 					ch <- testResult{err, []byte{}}
 					done <- true
-					return
 				}
 				ch <- testResult{nil, buff[:bytes]}
+				done <- true
 			}
-			done <- true
-		}()
+		}(c)
 	}
 
 	for i := 0; i < clientCt*msgCt; i++ {
@@ -103,6 +102,7 @@ func TestSendQueue(t *testing.T) {
 			res := <-dstCh
 			if res.err != nil {
 				t.Error(res.err)
+				break
 			} else {
 				t.Log(string(res.msg))
 			}


### PR DESCRIPTION
RouterContext.NewRouterContext() starts the processes for managing the queue and RouterContext.Close() kills them. This completes sender-->receiver traffic; next up is receiver-->sender. This will be managed similarly with a SendQueue called replyQueue. I will also be modifying the SendQueue error handler to pass error messages to the replyQueue. 