### PR TITLE
Implement SOCKS5 proxy and end-to-end testing.

### DIFF
--- a/go/apps/mixnet/README.md
+++ b/go/apps/mixnet/README.md
@@ -1,0 +1,169 @@
+Mixnet over CloudProxy
+======================
+
+A mixnet router facilitates anonymous communications among a set of peers.
+Alice wants to send Msg to Bob; she encrypts, authenticates, and sends the
+message (Msg, Bob) to Molly, a mixnet router. Molly waits until she has _n-1_
+more messages from _n-1_ other peers, then transmits the messages to their
+respective destinations simultaneously, thus anonymizing Alice among a set of n
+peers. Such a service is only useful if Molly can be trusted to not divulge the
+link (Alice, Bob). This document specifies a simple mixnet built on the
+CloudProxy platform that reduces this trust to the knowledge of a public key
+and trust in the owner of that key.
+
+Security goals and threat model
+-------------------------------
+There are three principals in our protocol: the sender, recipient, and the
+policy owner. Our goal is to design a protocol that provides anonymity for
+senders without requiring the recipient to execute the protocol. The policy
+owner controls the root policy private key that is used to attest to the
+instantiation of mixnet routers using the CloudProxy platform. CloudProxy
+exposes the code to the users, as well as the operating system in which it is
+running. To instantiate a mixnet router, a TPM coupled with the hardware
+platform generates a public key, which is attested to by the policy owner by
+signing it with the private policy key. When the machine boots, the OS is
+measured and generates a private/public key pair, which is attested to by the
+TPM; finally, the mixnet code itself is measured and generates a private/public
+key pair, which is attested to by the OS. Hence, trust in the mixnet
+routers to faithfully carry out the protocol is reduced to correct
+provisioning of the policy key.
+
+We consider a global passive adversary who observes all communications between
+senders and mixnet routers, mixnet routers and other mixnet routers, and mixnet
+routers and recipients. The adversary may also send messages on channels it
+observes. Since the service is anonymous, the adversary is allowed to control
+any number of senders or recipients. The effect is that the state of that peer
+is exposed, including any and all cryptographic keys. We assume that the policy
+key was correctly provisioned; if the code implements the protocol correctly and
+is properly isolated during its execution, we claim this precludes the
+possibility of exposing a router’s state. (This is a strong claim offered here
+without proof. CloudProxy provides assurance that the expected program is
+running; assuming the code does not contain any bugs that allow it to be
+comprimised, a formal treatment of our protocol should reduce the adversary's
+control of the routers to standard cryptographic assumptions: in particular,
+CDH on elliptic curves, as well as the integrity and confidentiality of the
+cipher suite underyling TLS.)
+
+The intended property of communications over the mixnet is unlinkability in the
+sense of [1]. Consider a set of senders _S_ where _|S| = n_ and a set of
+recipients _T_. Each sender chooses one recipient as well as a message to send
+so that _M : S → T_ is an onto mapping. The messages are transmitted to their
+respective recipients over the mixnet; the adversary succeeds if it outputs
+_(s, t)_ such that _M(s) = t_, unless it controls both _s_ and _t_. We say that
+communication over the mixnet is _unlinkable_ if for any adversary the
+probability of success is less than _1/n_ plus some negligible value.
+
+_Alternative definition:_ as above, except the adversary chooses the messages to
+be sent. This change may make it easier to analyze the unlinkability of a
+particular protocol. However, this would require the recipients to participate
+in the protocol, since messages exiting the mixnet must be encrypted.
+
+For a protocol to achieve security in this sense, the messages must all have the
+same length; of course, this is not always reasonable in practice. Mixnets
+address this by splitting messages into fixed-length cells. Senders split
+messages into cells (zero-padding the last cell as needed) and send them to the
+first router where they are added to a queue. At each round the router waits
+until there are _m_ cells in the queue from _m_ distinct senders and transmits
+these simultaneously to achieve anonymity.
+
+Extending the definition of unlinkability to a mixnet that divides messages into
+cells and transmits at rounds is challenging: the presence of
+variable-length messages exposes traffic patterns to the adversary. One way to
+mitigate this problem is to zero-pad all messages to the length of the longest
+message. This achieves a property called _unobservability_ [1] which is too
+expensive for our purposes.
+
+Another appraoch is to weaken the security model to one in which the adversary
+may only observe a fraction of the network at any one time; relaying messages
+over circuits of routers may make it more difficult to perform traffic
+analysis. This is the case for the design of the Tor onion-routing protocol [2].
+We will consider extending our protocol to a network of routers to achieve
+security in this model. This approach may have the added benifit of reducing
+latency of messages traversing the mixnet.
+
+Design
+------
+
+We designed the mixnet to proxy client/server protocols. There are
+two main components of the protocol: the _proxy_ (`mixnet_proxy`) accepts
+arbitrary TCP connections from a client and relays messages over the
+mixnet to the server; the _router_ (`mixnet_router`) accepts connections
+from a proxy and performs the mixnet operations. The proxy and router perform
+a one-way authenticated TLS handshake to exchange a key for wrapping
+(encrypting and authenticating) messages sent between them. Messages sent
+between proxies and routers (or routers and routers) are fixed length cells.
+
+The protocol for a single proxy and router is as follows.
+To send a message to a server, the client sends the message to the proxy
+which divides the message into cells and sends them to the router. The
+router waits until it has received all the cells, then assembles them into
+the original message. Once the router has queued messages from enough senders, it
+transmits the message to the server. It then waits for a reply from the server,
+divides the reply into cells, and queues the cells to be transmitted back to
+the proxy. The proxy waits until it has received all the reply cells, assembles
+them into the complete message, and sends it back to the client.
+
+The router maintains two data structures: the _sendQueue_ for sender to recipient
+traffic, and the _replyQueue_ for recipient to sender traffic. They are
+functionally equivalent (see `queue.go`); they receive cells from proxies (or other routers)
+and replies from recipients, and they send cells to proxies (or other routers)
+and messages to recipients. The _batchSize_ specifies how many messages/cells
+are waiting in the queue from distinct peers before transmitting
+them. When its time to transmit, a connection to the destination is established
+(if it hasn't been established already) and the messages are sent in a random
+order.
+
+A cell is either a chunk of a message or a _directive_. A directive contains
+instructions for a router or proxy and are implemented as protocol buffers
+(`mixnet.proto`):
+
+ * ERROR: something went wrong.
+ * CREATE: the proxy instructs the router to create a circuit over the mixnet
+           to a destination address. The response is either ERROR or CREATED.
+ * CREATED: the router informs the proxy that the circuit was created.
+ * DESTROY: the proxy instructs the router to destroy the circuit.
+
+Note that when a circuit is created, all that happens is the router is
+informed of the destination server. The connection is established when the
+router is ready to dequeue; otherwise, the TCP handshake would allow the
+adversary to correlate the wrapped CREATE directive with the TCP handshake.
+
+The router (`router.go`) is a Tao-delegated program and will only run when launched in a
+Tao environment. The proxy (`proxy.go`) is not launched in the Tao and is expected to run
+locally on the client's machine. It is assumed that the client has a copy
+of the root public policy key. When the proxy dials the router, the router
+attests to its identity, and the attestation is verified by the proxy using
+the policy key; if verification fails, the proxy exits. Both the proxy and
+router communicate with the TaoCA to obtain a copy of the policy.
+
+The proxy implements SOCKS [3], a widely a widely used protocol
+that allows a server to proxy client internet traffic. (See `socks.go`.)
+Our proxy only
+partially implements the server role; see `SocksListener.Accept()`
+for details. For example, it only allows the client to specify
+IPv4 addresses, which excludes DNS-based host names.
+
+Our implementation so far only allows a mixnet with a single router;
+router-to-router communication and construction/destruction of multi-hop
+circuits still need to be implemented. Notice that our design makes no attempt
+to preserve the confidentiality or integrity of cells _on the routers_; as a
+result, every router a message traverses would learn its intended destination,
+as well as the contents of the message. This problem is addressed in Tor using onion-routing,
+a technique that ensures each router knows only the previous and next hops in the circuit.
+Doing this in a way that preserves forward secrecy makes the circuit
+construction expensive, since the proxy needs to exchange a key with each hop
+successively. Since the client can be assured of the identity of the routers
+via the root of trust, and trusting the code is secure, we could construct the
+circuit in one pass.
+
+References
+----------
+
+[1] Andreas Pfitzman, 2010. _A terminology for talking about privacy by data_
+    _minimization: Anonymity, Unlinkability, Undetectability, Unobservability,_
+	_Pseudonymity, and Identity Management._
+	https://dud.inf.tu-dresden.de/literatur/Anon_Terminology_v0.34.pdf
+
+[2] Tor specification. https://svn.torproject.org/svn/projects/design-paper/tor-design.pdf
+
+[3] SOCKS Protocol Version 5. http://tools.ietf.org/html/rfc1928

--- a/go/apps/mixnet/conn.go
+++ b/go/apps/mixnet/conn.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"net"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 )
@@ -50,11 +51,13 @@ var dirDestroy = &Directive{Type: DirectiveType_DESTROY.Enum()}
 // protocol.
 type Conn struct {
 	net.Conn
-	id uint64 // Serial identifier of connection in a given context.
+	id      uint64        // Serial identifier of connection in a given context.
+	timeout time.Duration // timeout on read/write.
 }
 
 // Read a cell from the channel. If len(msg) != CellBytes, return an error.
-func (c Conn) Read(msg []byte) (n int, err error) {
+func (c *Conn) Read(msg []byte) (n int, err error) {
+	c.Conn.SetDeadline(time.Now().Add(c.timeout))
 	n, err = c.Conn.Read(msg)
 	if err != nil {
 		return n, err
@@ -67,6 +70,7 @@ func (c Conn) Read(msg []byte) (n int, err error) {
 
 // Write a cell to the channel. If the len(cell) != CellBytes, return an error.
 func (c *Conn) Write(msg []byte) (n int, err error) {
+	c.Conn.SetDeadline(time.Now().Add(c.timeout))
 	if len(msg) != CellBytes {
 		return 0, errCellLength
 	}
@@ -77,6 +81,13 @@ func (c *Conn) Write(msg []byte) (n int, err error) {
 	return n, nil
 }
 
+// GetID returns the connection's serial ID.
+func (c *Conn) GetID() uint64 {
+	return c.id
+}
+
+// Transform a directive into a cell, encoding its length and padding it to the
+// length of a cell.
 func marshalDirective(d *Directive) ([]byte, error) {
 	db, err := proto.Marshal(d)
 	if err != nil {
@@ -97,6 +108,7 @@ func marshalDirective(d *Directive) ([]byte, error) {
 	return cell, nil
 }
 
+// Parse a directive from a cell.
 func unmarshalDirective(cell []byte, d *Directive) error {
 	if cell[0] != dirCell {
 		return errCellType
@@ -108,23 +120,4 @@ func unmarshalDirective(cell []byte, d *Directive) error {
 	}
 
 	return nil
-}
-
-// SendDirective serializes and pads a directive to the length of a cell and
-// sends it to the peer. A directive is signaled to the receiver by the first
-// byte of the cell. The next few bytes encode the length of of the serialized
-// protocol buffer. If the buffer doesn't fit in a cell, then throw an error.
-func (c *Conn) SendDirective(d *Directive) (int, error) {
-	cell, err := marshalDirective(d)
-	if err != nil {
-		return 0, err
-	}
-	return c.Write(cell)
-}
-
-// Write zeros to each byte of a cell.
-func zeroCell(cell []byte) {
-	for i := 0; i < CellBytes; i++ {
-		cell[i] = 0
-	}
 }

--- a/go/apps/mixnet/queue_test.go
+++ b/go/apps/mixnet/queue_test.go
@@ -22,24 +22,29 @@ import (
 )
 
 // A dummy sever that reads a message from the connecting client.
-func runDummyServerReadOne(ch chan<- testResult) {
+func runDummyServerOne(ch chan<- testResult) {
 	l, err := net.Listen(network, dstAddr)
 	if err != nil {
-		ch <- testResult{err, []byte{}}
+		ch <- testResult{err, nil}
 		return
 	}
 	defer l.Close()
 
 	c, err := l.Accept()
 	if err != nil {
-		ch <- testResult{err, []byte{}}
+		ch <- testResult{err, nil}
 		return
 	}
 	defer c.Close()
 
-	buf := make([]byte, CellBytes*10)
+	buf := make([]byte, MaxMsgBytes)
 	bytes, err := c.Read(buf)
 	if err != nil {
+		ch <- testResult{err, nil}
+		return
+	}
+
+	if _, err = c.Write(buf[:bytes]); err != nil {
 		ch <- testResult{err, nil}
 		return
 	}

--- a/go/apps/mixnet/router.go
+++ b/go/apps/mixnet/router.go
@@ -114,7 +114,7 @@ func (hp *RouterContext) AcceptProxy() (*Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Conn{c, hp.nextID()}, nil
+	return &Conn{c, hp.nextID(), hp.timeout}, nil
 }
 
 // Close releases any resources held by the hosted program.
@@ -173,7 +173,7 @@ func (hp *RouterContext) HandleProxy(c *Conn) error {
 
 		msg = <-reply
 		if msg != nil {
-			zeroCell(cell)
+			tao.ZeroBytes(cell)
 			msgBytes := len(msg)
 
 			cell[0] = msgCell
@@ -182,7 +182,7 @@ func (hp *RouterContext) HandleProxy(c *Conn) error {
 			hp.replyQueue.EnqueueMsg(c.id, cell)
 
 			for bytes < msgBytes {
-				zeroCell(cell)
+				tao.ZeroBytes(cell)
 				cell[0] = msgCell
 				bytes += copy(cell[1:], msg[bytes:])
 				hp.replyQueue.EnqueueMsg(c.id, cell)

--- a/go/apps/mixnet/socks5.go
+++ b/go/apps/mixnet/socks5.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2015, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mixnet
+
+import (
+	"errors"
+	"net"
+	"strconv"
+)
+
+// Codes used in the RFC standard of SOCKS version 5.
+const (
+	SocksVersion            = 0x05
+	SocksMethodNoAuth       = 0x00
+	SocksNoAcceptableMethod = 0xff
+	SocksCmdConnect         = 0x01
+	SocksAtypIPv4           = 0x01
+	SocksRepSuccess         = 0x00
+	SocksRepFailure         = 0x01
+	SocksRepUnsupported     = 0x07
+)
+
+// SocksConn implements the net.Conn interface and contains a destination
+// network and address for the proxy.
+type SocksConn struct {
+	net.Conn
+	network, dstAddr string // Destination network and address.
+}
+
+// DestinationAddr returns the destination address negotiated in the SOCKS
+// protocol.
+func (c *SocksConn) DestinationAddr() string {
+	return c.dstAddr
+}
+
+// SocksListener implements the net.Listener interface as a SOCKS server. This
+// program partially implements the server role in version 5 of the SOCKS
+// protocol specified in RFC 1928. In particular, it only supports TCP clients
+// with no authentication who request CONNECT to IPv4 addresses; neither BIND
+// nor UDP ASSOCIATE are supported.
+type SocksListener struct {
+	net.Listener
+	network string // Network protocol for proxying, e.g. "tcp".
+}
+
+// SocksListen binds an address to a socket and returns a
+// SocksListener for serving SOCKS clients.
+func SocksListen(network, addr string) (net.Listener, error) {
+	l, err := net.Listen(network, addr)
+	if err != nil {
+		return nil, err
+	}
+	return &SocksListener{l, network}, nil
+}
+
+// Accept exposes the SOCKS5 protocol to connecting client. Return the
+// connection and the requested destination address.
+func (l *SocksListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	// First, wait for greeting from client containing the SOCKS version and
+	// requested methods.
+	msg := make([]byte, MaxMsgBytes)
+	reply := make([]byte, MaxMsgBytes)
+	bytes, err := c.Read(msg)
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+
+	// Parse client's greeting, making sure that it is the proper length.
+	// Only the NO AUTHENTICATION REQUIRED method is allowed. Note that this
+	// makes the server non-compliant since GSSAPI is not allowed.
+	ok := false
+	var ver, nmethods int
+	if bytes > 2 {
+		ver = int(msg[0])
+		nmethods = int(msg[1])
+		if bytes >= 2+nmethods {
+			for _, method := range msg[2 : 2+nmethods] {
+				if method == SocksMethodNoAuth {
+					ok = true
+					break
+				}
+			}
+		}
+	}
+
+	// Second, reply with selected method.
+	reply[0] = SocksVersion
+	if ok {
+		reply[1] = SocksMethodNoAuth
+	} else {
+		reply[1] = SocksNoAcceptableMethod
+	}
+
+	if _, err = c.Write(reply[:2]); err != nil {
+		c.Close()
+		return nil, err
+	}
+
+	// If NO ACCEPTABLE METHOD, the client closes the connection.
+	if !ok {
+		c.Close()
+		return nil, errors.New("socks: client did not provide acceptable method")
+	}
+
+	// Third, wait for command from client.
+	bytes, err = c.Read(msg)
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+
+	// Test that client's command is long enough. It must be at least 6 bytes long
+	// to accomadate the version, command, reserved byte, address type, and
+	// destination port.
+	if bytes < 6 {
+		reply[0] = SocksVersion
+		reply[1] = SocksRepFailure
+		for i := 2; i < 6; i++ {
+			reply[i] = 0x00
+		}
+		defer c.Close()
+		if _, err = c.Write(reply[:6]); err != nil {
+			return nil, err
+		}
+		return nil, errors.New("socks: client sent a malformed command")
+	}
+
+	ver = int(msg[0])
+	cmd := msg[1]
+	// msg[2] is a reserved byte in the protocol.
+	atyp := msg[3]
+
+	// Only CONNECT to IPv4 addresses is allowed. Since traffic will be proxied
+	// over the mixnet, don't connect to the intended host just yet. Reply to
+	// the client.
+	copy(reply, msg[:bytes])
+	if ver == SocksVersion && cmd == SocksCmdConnect /* CONNECT */ && atyp == SocksAtypIPv4 /* IPv4 */ {
+		reply[1] = SocksRepSuccess
+	} else {
+		reply[1] = SocksRepUnsupported
+	}
+	if _, err = c.Write(reply[:bytes]); err != nil {
+		c.Close()
+		return nil, err
+	}
+
+	// dstAddr specifies the destination of the client. At this point the
+	// proxy is ready to construct a circuit and relay a message on behalf of
+	// the client.
+	port := strconv.Itoa((int(msg[bytes-2]) << 8) + int(msg[bytes-1]))
+	dstAddr := strconv.Itoa(int(msg[4])) + "." +
+		strconv.Itoa(int(msg[5])) + "." +
+		strconv.Itoa(int(msg[6])) + "." +
+		strconv.Itoa(int(msg[7])) + ":" + port
+
+	return &SocksConn{c, l.network, dstAddr}, nil
+}

--- a/go/apps/mixnet/socks5_test.go
+++ b/go/apps/mixnet/socks5_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2015, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mixnet
+
+import (
+	"testing"
+
+	netproxy "golang.org/x/net/proxy"
+)
+
+// Run proxy server.
+func runSocksServerOne(proxy *ProxyContext, ch chan<- testResult) {
+	c, err := proxy.Accept()
+	if err != nil {
+		ch <- testResult{err, nil}
+		return
+	}
+	defer c.Close()
+	addr := c.(*SocksConn).dstAddr
+
+	d, err := proxy.CreateCircuit(routerAddr, addr)
+	if err != nil {
+		ch <- testResult{err, nil}
+		return
+	}
+
+	if err = proxy.HandleClient(c, d); err != nil {
+		ch <- testResult{err, nil}
+		return
+	}
+
+	if err = proxy.DestroyCircuit(d); err != nil {
+		ch <- testResult{err, nil}
+		return
+	}
+
+	ch <- testResult{err, []byte(addr)}
+}
+
+// Connect to a destination through a mixnet proxy, send a message,
+// and wait for a response.
+func runSocksClient(proxyAddr string, msg []byte) testResult {
+	dialer, err := netproxy.SOCKS5(network, proxyAddr, nil, netproxy.Direct)
+	if err != nil {
+		return testResult{err, nil}
+	}
+
+	c, err := dialer.Dial(network, dstAddr)
+	if err != nil {
+		return testResult{err, nil}
+	}
+	defer c.Close()
+
+	if _, err = c.Write(msg); err != nil {
+		return testResult{err, nil}
+	}
+
+	bytes, err := c.Read(msg)
+	if err != nil {
+		return testResult{err, nil}
+	}
+
+	return testResult{nil, msg[:bytes]}
+}
+
+// Test the SOCKS proxy server.
+func TestSocks(t *testing.T) {
+
+	proxy, err := makeProxyContext(proxyAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proxy.Close()
+
+	ch := make(chan testResult)
+	go func() {
+		c, err := proxy.Accept()
+		if err != nil {
+			ch <- testResult{err, nil}
+			return
+		}
+		c.Close()
+		ch <- testResult{nil, []byte(c.(*SocksConn).dstAddr)}
+	}()
+
+	dialer, err := netproxy.SOCKS5(network, proxyAddr, nil, netproxy.Direct)
+	if err != nil {
+		t.Error(err)
+	}
+
+	c, err := dialer.Dial(network, dstAddr)
+	if err != nil {
+		t.Error(err)
+	}
+	c.Close()
+
+	res := <-ch
+	if res.err != nil {
+		t.Error(res.err)
+	} else {
+		t.Log("server got:", string(res.msg))
+	}
+}

--- a/go/run/scripts/test_mixnet.sh
+++ b/go/run/scripts/test_mixnet.sh
@@ -20,13 +20,13 @@ sudo test true
 
 
 ### Create domain.
-echo "----------------- Creating domain."
+echo "Creating domain."
 GUARD="Datalog"
 SCRIPT_PATH="$(readlink -e "$(dirname "$0")")"
 TEMPLATE="${SCRIPT_PATH}"/domain_template.pb
 ADMIN="$(gowhich tao_admin)"
 HOST_REL_PATH=linux_tao_host
-CA_ADDR="localhost:8124"
+CA_ADDR="127.0.0.1:8124"
 
 TEMP_FILE=`mktemp /tmp/domain_template.XXXXXX`
 cat "$TEMPLATE" | sed "s/REPLACE_WITH_DOMAIN_GUARD_TYPE/$GUARD/g" > $TEMP_FILE
@@ -50,37 +50,62 @@ echo host_name: \"$KEY_NAME\" >> $TEMP_FILE
 mkdir -p "${DOMAIN}.pub/${HOST_REL_PATH}"
 cp $DOMAIN/$HOST_REL_PATH/{cert,keys} "${DOMAIN_PUB}/${HOST_REL_PATH}"
 echo "Temp public domain directory: ${DOMAIN_PUB}"
-
+echo
 
 ### Start TaoCA.
-echo "----------------- Starting TaoCA"
+echo "Starting TaoCA"
 "$(gowhich tcca)" -config ${DOMAIN}/tao.config -password ${FAKE_PASS} &
 CAPID=$!
-sleep 2
+sleep 1
+echo
 
 ### Start LinuxHost.
-echo "----------------- Starting LinuxHost"
+echo "Starting LinuxHost"
 sudo "$(gowhich linux_host)" -config_path ${DOMAIN_PUB}/tao.config \
      -pass ${FAKE_PASS} &
 HOSTPID=$!
-sleep 2
+sleep 1
+echo
 
+SERVER_MSG="Who is this?"
+CLIENT_MSG="I am the enigma."
+
+### Start a dummy server.
+echo "Starting a test server"
+(echo "$SERVER_MSG" | $(which nc) -l 8080 > /tmp/serverout) &
+SERVERPID=$!
 
 ### Start mixnet router.
-echo "Starting Mixnet Router"
-DSPID=$("$(gowhich tao_launch)" -sock ${DOMAIN_PUB}/linux_tao_host/admin_socket \
-	"$(gowhich mixnet_router)" -config=${DOMAIN_PUB}/tao.config)
-
+echo "Starting mixnet router"
+ROUTERPID=$("$(gowhich tao_launch)" -sock ${DOMAIN_PUB}/linux_tao_host/admin_socket \
+	"$(gowhich mixnet_router)" -config=${DOMAIN_PUB}/tao.config -batch=1)
+sleep 1
 
 ### Start mixnet proxy.
-echo "Starting Mixnet Proxy"
-"$(gowhich mixnet_proxy)" -config=${DOMAIN_PUB}/tao.config
+echo "Starting mixnet proxy"
+"$(gowhich mixnet_proxy)" -config=${DOMAIN_PUB}/tao.config &
+PROXYPID=$!
+sleep 1
 
-echo "Waiting for the tests to finish"
-sleep 2
+### Run client.
+echo "Starting a client"
+echo "$CLIENT_MSG" | $(which nc) 127.0.0.1 8080 -X 5 -x 127.0.0.1:1080 > /tmp/clientout
 
-echo "Cleaning up remaining programs"
-kill $DSPID
-kill $CAPID
-sudo kill $HOSTPID
+if [ "$(cat /tmp/serverout)" != "$CLIENT_MSG" ]; then
+  echo "Server got the wrong message: $(cat /tmp/serverout)"
+else
+  echo "Server passed!"
+fi
+
+if [ "$(cat /tmp/clientout)" != "$SERVER_MSG" ]; then
+  echo "Client got the wrong message: $(cat /tmp/clientout)"
+else
+  echo "Client passed!"
+fi
+
+echo -e "\nCleaning up remaining programs"
 sudo rm -f ${DOMAIN_PUB}/linux_tao_host/admin_socket
+kill $PROXYPID
+kill $ROUTERPID
+killall tcca
+sudo kill $HOSTPID


### PR DESCRIPTION
ProxyContext now binds a socket to a port that exposes the SOCKS5 protocol to clients. This is meant to allow routing arbitrary protocols over mixnet. This pull request improves the coverage of testing (including timeouts) and an end-to-end test which runs a single router and destination with many client/proxies. test_mixnet.sh has has been modified to test with netcat.