### PR TITLE
Fix #6 by limiting the length of auth principals to the max principal length in a DatalogGuard query.

### DIFF
--- a/go/run/scripts/domain_template.pb
+++ b/go/run/scripts/domain_template.pb
@@ -29,15 +29,15 @@ config: {
 
 datalog_rules: "(forall P: forall Host: forall Hash: TrustedHost(Host) and TrustedProgramHash(Hash) and Subprin(P, Host, Hash) implies MemberProgram(P))"
 datalog_rules: "(forall P: forall Host: forall Hash: TrustedHost(Host) and TrustedContainerHash(Hash) and Subprin(P, Host, Hash) implies MemberProgram(P))"
-datalog_rules: "(forall P: forall Host: forall Hash: TrustedVMHost(Host) and TrustedProgramHash(Hash) and Subprin(P, Host, Hash) implies MemberProgram(P))"
-datalog_rules: "(forall P: forall Host: forall Hash: TrustedGuardedHost(Host) and TrustedProgramHash(Hash) and Subprin(P, Host, Hash) implies MemberProgram(P))"
+
+datalog_rules: "(forall P: forall VM: forall Guard: TrustedHost(VM) and TrustedGuard(Guard) and Subprin(P, VM, Guard) implies TrustedHost(P))"
+
+datalog_rules: "(forall P: forall VM: forall Host: TrustedHost(Host) and TrustedVMImage(VM) and Subprin(P, Host, VM) implies TrustedVM(P))"
+datalog_rules: "(forall P: forall VM: forall Hash: TrustedVM(VM) and TrustedHost(Hash) and Subprin(P, VM, Hash) implies TrustedHost(P))"
 
 datalog_rules: "(forall T: forall PCRs: forall P: TrustedTPM(T) and TrustedOS(PCRs) and Subprin(P, T, PCRs) implies TrustedHost(P))"
-datalog_rules: "(forall P: forall VM: forall Host: TrustedHost(Host) and TrustedVMImage(VM) and Subprin(P, Host, VM) implies TrustedVM(P))"
-datalog_rules: "(forall P: forall VM: forall Hash: TrustedVM(VM) and TrustedLinuxHost(Hash) and Subprin(P, VM, Hash) implies TrustedVMHost(P))"
-datalog_rules: "(forall P: forall VM: forall Guard: TrustedVMHost(VM) and TrustedGuard(Guard) and Subprin(P, VM, Guard) implies TrustedGuardedHost(P))"
 
-datalog_rules: "(forall P: TrustedVMHost(P) implies Authorized(P, \"Execute\"))"
+datalog_rules: "(forall P: TrustedHost(P) implies Authorized(P, \"Execute\"))"
 datalog_rules: "(forall P: MemberProgram(P) implies Authorized(P, \"Execute\"))"
 
 host_predicate_name: "TrustedHost"
@@ -55,7 +55,7 @@ vm_paths: "coreos_production_qemu_image.img"
 vm_predicate_name: "TrustedVMImage"
 
 linux_host_paths: "linux_host.img.tgz"
-linux_host_predicate_name: "TrustedLinuxHost"
+linux_host_predicate_name: "TrustedHost"
 
 guard_predicate_name: "TrustedGuard"
 tpm_predicate_name: "TrustedTPM"


### PR DESCRIPTION
These commits add functions to compute the max length of principals in a DatalogGuard query. The DatalogGuard uses these in its subprin/3 implementation to skip (Var, Const, Const) discovery if the principal formed from the two constants has a length greater than the maximum length allowed.