### PR TITLE
Refactor management of Tao-delegated keys on disk.

### DIFF
--- a/go/tao/keys.pb.go
+++ b/go/tao/keys.pb.go
@@ -248,6 +248,7 @@ func (m *CryptoKey) GetKey() []byte {
 
 type CryptoKeyset struct {
 	Keys             []*CryptoKey `protobuf:"bytes,1,rep,name=keys" json:"keys,omitempty"`
+	Delegation       *Attestation `protobuf:"bytes,2,opt,name=delegation" json:"delegation,omitempty"`
 	XXX_unrecognized []byte       `json:"-"`
 }
 
@@ -258,6 +259,13 @@ func (*CryptoKeyset) ProtoMessage()    {}
 func (m *CryptoKeyset) GetKeys() []*CryptoKey {
 	if m != nil {
 		return m.Keys
+	}
+	return nil
+}
+
+func (m *CryptoKeyset) GetDelegation() *Attestation {
+	if m != nil {
+		return m.Delegation
 	}
 	return nil
 }

--- a/go/tao/proto/keys.proto
+++ b/go/tao/proto/keys.proto
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import "attestation.proto";
+
 package tao;
 
 // TODO(kwalsh) add finer-granularity version tags?
@@ -40,10 +42,11 @@ message CryptoKey {
 
 message CryptoKeyset {
   repeated CryptoKey keys = 1;
+  optional Attestation delegation = 2;
 }
 
 // Stacked Tao hosts can invoke their host Tao to seal a serialized CryptoKeyset
-// (or individual CryptoKeys). 
+// (or individual CryptoKeys).
 
 // PBEData is used by root Tao hosts to seal a serialized CryptoKeyset
 // using a user-chosen password.


### PR DESCRIPTION
NewOnDiskTaoSealedKeys() manages a set of keys delegated by the parent Tao. This pull request maintains this functionality, but refactors the code so that unsealed key sets can be loaded from the file system. This is useful for downstream integration.