### PR TITLE
Implement CachedGuard.AddRule, add flexibility to auth language. 

### DIFF
--- a/go/tao/auth/ast.go
+++ b/go/tao/auth/ast.go
@@ -106,7 +106,7 @@ var _ fmt.Scanner = &AnyTerm{}
 // signatures on credentials issued by the principal, and a sequence of zero or
 // more extensions to identify the subprincipal of that key.
 type Prin struct {
-	Type string  // either "key" or "tpm".
+	Type string  // The keyword of a principal token, e.g. "key" or "tpm".
 	Key  Term    // TermVar or Bytes with marshalled CryptoKey protobuf structure with purpose CryptoKey.VERIFYING. Or this can be a marshalled TPM AIK, or a X.509 certificate, marshalled as ASN.1 DER.
 	Ext  SubPrin // zero or more extensions for descendents
 }

--- a/go/tao/auth/auth_test.go
+++ b/go/tao/auth/auth_test.go
@@ -30,6 +30,7 @@ var key = []string{
 }
 
 var termtests = []string{
+	`bogus([face])`,
 	"42",
 	"0",
 	"-1",

--- a/go/tao/auth/lexer.go
+++ b/go/tao/auth/lexer.go
@@ -71,8 +71,6 @@ var (
 	tokenFalse     = token{itemKeyword, "false"}
 	tokenTrue      = token{itemKeyword, "true"}
 	tokenExt       = token{itemKeyword, "ext"}
-	tokenKey       = token{itemKeyword, "key"}
-	tokenTPM       = token{itemKeyword, "tpm"}
 	tokenLP        = token{itemLP, '('}
 	tokenRP        = token{itemRP, ')'}
 	tokenComma     = token{itemComma, ','}
@@ -80,6 +78,16 @@ var (
 	tokenColon     = token{itemColon, ':'}
 	tokenEOF       = token{itemEOF, nil}
 )
+
+var prinTokens = map[token]bool{
+	token{itemKeyword, "tpm"}: true,
+	token{itemKeyword, "key"}: true,
+}
+
+func isPrinToken(i token) bool {
+	_, ok := prinTokens[i]
+	return ok
+}
 
 // String returns pretty-printed token, e.g. for debugging.
 func (i token) String() string {

--- a/go/tao/auth/lexer.go
+++ b/go/tao/auth/lexer.go
@@ -89,6 +89,12 @@ func isPrinToken(i token) bool {
 	return ok
 }
 
+func AddPrinTokens(keywords ...string) {
+	for _, keyword := range keywords {
+		prinTokens[token{itemKeyword, keyword}] = true
+	}
+}
+
 // String returns pretty-printed token, e.g. for debugging.
 func (i token) String() string {
 	switch i.typ {

--- a/go/tao/auth/lexer.go
+++ b/go/tao/auth/lexer.go
@@ -79,20 +79,30 @@ var (
 	tokenEOF       = token{itemEOF, nil}
 )
 
-var prinTokens = map[token]bool{
-	token{itemKeyword, "tpm"}: true,
-	token{itemKeyword, "key"}: true,
+var reservedKeywordTokens = map[token]bool{
+	tokenFrom:      true,
+	tokenUntil:     true,
+	tokenSays:      true,
+	tokenSpeaksfor: true,
+	tokenForall:    true,
+	tokenExists:    true,
+	tokenImplies:   true,
+	tokenOr:        true,
+	tokenAnd:       true,
+	tokenNot:       true,
+	tokenFalse:     true,
+	tokenTrue:      true,
+	tokenExt:       true,
 }
 
+// isPrinToken checks if the input is a principal token. A principal tokens
+// is a keyword not in the set of reserved keywords.
 func isPrinToken(i token) bool {
-	_, ok := prinTokens[i]
-	return ok
-}
-
-func AddPrinTokens(keywords ...string) {
-	for _, keyword := range keywords {
-		prinTokens[token{itemKeyword, keyword}] = true
+	_, ok := reservedKeywordTokens[i]
+	if !ok && i.typ == itemKeyword && lower(rune(i.val.(string)[0])) {
+		return true
 	}
+	return false
 }
 
 // String returns pretty-printed token, e.g. for debugging.

--- a/go/tao/auth/parser.go
+++ b/go/tao/auth/parser.go
@@ -340,18 +340,13 @@ func (p *parser) expectTerm() (Term, error) {
 	case itemInt:
 		return p.expectInt()
 	case itemKeyword:
-		// All keywords have a string value.
-		s, ok := p.cur().val.(string)
-		if !ok {
-			return nil, fmt.Errorf("a keyword must be a string")
-		}
 		switch {
 		case p.cur() == tokenExt:
 			return p.expectPrinTail()
 		case isPrinToken(p.cur()):
 			return p.expectPrin()
 		default:
-			return nil, fmt.Errorf(`expected keyword of principal token or ext, found %s`, s)
+			return nil, fmt.Errorf(`expected keyword of principal token or ext, found %s`, p.cur().val)
 		}
 	case itemIdentifier:
 		return p.expectTermVar()

--- a/go/tao/auth/parser.go
+++ b/go/tao/auth/parser.go
@@ -351,7 +351,7 @@ func (p *parser) expectTerm() (Term, error) {
 		case isPrinToken(p.cur()):
 			return p.expectPrin()
 		default:
-			return nil, fmt.Errorf(`expected keyword of principal token, found %s`, s)
+			return nil, fmt.Errorf(`expected keyword of principal token or ext, found %s`, s)
 		}
 	case itemIdentifier:
 		return p.expectTermVar()

--- a/go/tao/cached_guard.go
+++ b/go/tao/cached_guard.go
@@ -51,7 +51,7 @@ const (
 	ACLs
 )
 
-var errCachedGuardModify = errors.New("CachedGuard: modifying cached policy is not allowed.")
+var errCachedNotImplemented = errors.New("CachedGuard: not implemented.")
 var errCachedGuardSave = errors.New("CachedGuard: saving cached policy is not allowed.")
 var errCachedGuardReload = errors.New("CachedGuard: failed to update policy.")
 
@@ -124,12 +124,12 @@ func (cg *CachedGuard) Save(key *Signer) error {
 // Authorize is not allowed for cached guards, since it doesn't have the
 // private policy key.
 func (cg *CachedGuard) Authorize(name auth.Prin, op string, args []string) error {
-	return errCachedGuardModify
+	return errCachedNotImplemented
 }
 
 // Retract is not allowed for cached guards.
 func (cg *CachedGuard) Retract(name auth.Prin, op string, args []string) error {
-	return errCachedGuardModify
+	return errCachedNotImplemented
 }
 
 // IsAuthorized checks if the principal `name` is authorized to perform `op`
@@ -145,12 +145,17 @@ func (cg *CachedGuard) IsAuthorized(name auth.Prin, op string, args []string) bo
 
 // AddRule is not allowed for cached guards.
 func (cg *CachedGuard) AddRule(rule string) error {
-	return errCachedGuardModify
+	if cg.guard == nil || cg.IsExpired() {
+		if err := cg.Reload(); err != nil {
+			return err
+		}
+	}
+	return cg.guard.AddRule(rule)
 }
 
 // RetractRule is not allowed for cached guards.
 func (cg *CachedGuard) RetractRule(rule string) error {
-	return errCachedGuardModify
+	return errCachedNotImplemented
 }
 
 // Clear deletes the guard. This will cause a Reload() the next time the guard

--- a/go/tao/cached_guard_test.go
+++ b/go/tao/cached_guard_test.go
@@ -77,11 +77,9 @@ func makeTestDomains(configDir, network, addr string, ttl int64) (policy *Domain
 }
 
 func TestCachingDatalogLoad(t *testing.T) {
-	var network, addr string
-	var ttl int64
-	network = "tcp"
-	addr = "localhost:0"
-	ttl = 1
+	network := "tcp"
+	addr := "localhost:0"
+	ttl := int64(1)
 	configDir := "/tmp/domain_test"
 
 	ch := make(chan bool)
@@ -116,11 +114,9 @@ func TestCachingDatalogLoad(t *testing.T) {
 
 func TestCachingDatalogReload(t *testing.T) {
 
-	var network, addr string
-	var ttl int64
-	network = "tcp"
-	addr = "localhost:0"
-	ttl = 10
+	network := "tcp"
+	addr := "localhost:0"
+	ttl := int64(10)
 
 	// Run the TaoCA. This handles one request and then exits.
 	ch := make(chan bool)
@@ -183,13 +179,11 @@ func TestCachingDatalogReload(t *testing.T) {
 // execute according to the policy. The policy is set up and the policy
 // key is used to attest to the identity of the server. The attestation
 // includes an endorsement of the service itself. The client verifies the
-// endorsement and adds the predicate to the policy before it checking.
+// endorsement and adds the predicate to the policy before checking it.
 func TestCachingDatalogValidatePeerAttestation(t *testing.T) {
-	var network, addr string
-	var ttl int64
-	network = "tcp"
-	addr = "localhost:0"
-	ttl = 1
+	network := "tcp"
+	addr := "localhost:0"
+	ttl := int64(1)
 	tmpDir := "/tmp/domain_test"
 
 	// Set up the TaoCA.

--- a/go/tao/client.go
+++ b/go/tao/client.go
@@ -227,7 +227,7 @@ func AddEndorsements(guard Guard, a *Attestation, v *Verifier) error {
 			return fmt.Errorf("the signature on an endorsement didn't pass verification")
 		}
 
-		guard.AddRule(pred.String())
+		return guard.AddRule(pred.String())
 	}
 
 	return nil

--- a/go/tao/datalog_guard.go
+++ b/go/tao/datalog_guard.go
@@ -78,7 +78,7 @@ type DatalogGuard struct {
 	modTime time.Time // Modification time of signed rules file at time of reading.
 	db      DatalogRules
 	dl      *dlengine.Engine
-	sp	*subprinPrim
+	sp      *subprinPrim
 }
 
 // subprinPrim is a custom datalog primitive that implements subprincipal
@@ -195,7 +195,7 @@ func (sp *subprinPrim) Search(target *datalog.Literal, discovered func(c *datalo
 		}
 		oprin.Ext = append(oprin.Ext, eprin.Ext...)
 		oeIdent := dlengine.NewIdent(fmt.Sprintf("%q", oprin.String()))
-		if len(oprin.Ext) + 1 <= sp.max {
+		if len(oprin.Ext)+1 <= sp.max {
 			discovered(datalog.NewClause(datalog.NewLiteral(sp, oeIdent, o, e)))
 		}
 	} else if p.Constant() && o.Constant() && e.Constant() {

--- a/go/tao/datalog_guard_test.go
+++ b/go/tao/datalog_guard_test.go
@@ -248,37 +248,6 @@ func TestDatalogSubprin(t *testing.T) {
 	}
 }
 
-// Test adding a principal token to the authorization language on the fly.
-// Add a predicate of a new principal type and test that it is authorized.
-func TestDatalogAddPrinToken(t *testing.T) {
-	g, keys, tmpdir, err := makeDatalogGuard()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-
-	auth.AddPrinTokens("bogus")
-	prin := auth.Prin{
-		Type: "bogus",
-		Key:  auth.Bytes{0xfa, 0xce},
-	}
-
-	pred := auth.MakePredicate("IsBogus", prin)
-	if err = g.AddRule(pred.String()); err != nil {
-		t.Error(err)
-		return
-	}
-	if err := g.Save(keys.SigningKey); err != nil {
-		t.Fatal("Couldn't save the guard:", err)
-	}
-
-	if ok, err := g.Query(pred.String()); err != nil {
-		t.Error("query returned error:", err)
-	} else if !ok {
-		t.Error("query should have returned true")
-	}
-}
-
 var datalogFormLengthChecks = []struct {
 	query  string
 	length int


### PR DESCRIPTION
Test AddEndorsements() and ValidatePeerAttestation() with a public, cached DatalogGuard to make sure the client adds endorsements to the policy properly. (@tmroeder: Tom, could you have a look?)

The principal types are hardcoded as tokens in the auth language. Currently the parser checks whether the principal is "tpm" or "key". This commit checks membership in a map to determine if a string is a principal token, which makes it easier to specify other types of principals. (@kevinawalsh: since I've modified the authentication language, I thought you should have a look. Thanks!)
