### PR TITLE
Add support for registering arbitrary Tao channels.

### DIFF
--- a/go/apps/linux_host/linux_host.go
+++ b/go/apps/linux_host/linux_host.go
@@ -256,13 +256,13 @@ func loadHost(domain *tao.Domain, cfg *tao.LinuxHostConfig) (*tao.LinuxHost, err
 	if tc.HostType == tao.Stacked {
 		switch cfg.GetParentType() {
 		case "TPM":
-			tc.HostChannelType = tao.TPM
+			tc.HostChannelType = "tpm"
 		case "pipe":
-			tc.HostChannelType = tao.Pipe
+			tc.HostChannelType = "pipe"
 		case "file":
-			tc.HostChannelType = tao.File
+			tc.HostChannelType = "file"
 		case "unix":
-			tc.HostChannelType = tao.Unix
+			tc.HostChannelType = "unix"
 		case "":
 			options.Usage("Must supply -parent_type for stacked hosts")
 		default:
@@ -270,7 +270,7 @@ func loadHost(domain *tao.Domain, cfg *tao.LinuxHostConfig) (*tao.LinuxHost, err
 		}
 
 		// For stacked hosts on anything but a TPM, we also need parent spec
-		if tc.HostChannelType != tao.TPM {
+		if tc.HostChannelType != "tpm" {
 			tc.HostSpec = cfg.GetParentSpec()
 			if tc.HostSpec == "" {
 				options.Usage("Must supply -parent_spec for non-TPM stacked hosts")

--- a/go/tao/config.go
+++ b/go/tao/config.go
@@ -36,27 +36,6 @@ var HostTaoTypeMap = map[string]HostTaoType{
 	"stacked": Stacked,
 }
 
-// The HostTaoChannelType represents the type of the host Tao for a Stacked Tao.
-type HostTaoChannelType int
-
-// These constants given the different types of host Tao.
-const (
-	NoChannel HostTaoChannelType = iota
-	TPM
-	Pipe
-	File
-	Unix
-)
-
-// HostTaoChannelMap maps strings to the type of a host Tao channel.
-var HostTaoChannelMap = map[string]HostTaoChannelType{
-	"none": NoChannel,
-	"tpm":  TPM,
-	"pipe": Pipe,
-	"file": File,
-	"unix": Unix,
-}
-
 // The HostedProgramType represents the type of hosted programs and the channel
 // type used for communication between the Host and the Hosted Program.
 type HostedProgramType int
@@ -82,7 +61,7 @@ var HostedProgramTypeMap = map[string]HostedProgramType{
 // it creates Hosted Programs.
 type Config struct {
 	HostType        HostTaoType
-	HostChannelType HostTaoChannelType
+	HostChannelType string
 	HostSpec        string
 	HostedType      HostedProgramType
 
@@ -103,14 +82,14 @@ func (tc Config) IsValid() bool {
 	case NoHost:
 		return false
 	case Root:
-		if tc.HostChannelType != NoChannel || tc.HostType != NoHost {
+		if tc.HostChannelType != "none" || tc.HostType != NoHost {
 			return false
 		}
 
 		// There are no constraints on the hosted-program types for a
 		// root Tao.
 	case Stacked:
-		if tc.HostChannelType == NoChannel || tc.HostSpec == "" {
+		if tc.HostChannelType == "none" || tc.HostSpec == "" {
 			return false
 		}
 	default:
@@ -135,24 +114,13 @@ func NewConfigFromString(htt, htct, f, hpt, tpmaik, tpmpcrs, tpmdev string) Conf
 		tc.HostType = NoHost
 	}
 
-	switch htct {
-	case "none":
-		tc.HostChannelType = NoChannel
-	case "tpm":
-		tc.HostChannelType = TPM
+	tc.HostChannelType = htct
+	if htct == "tpm" {
 		// TODO(tmroeder): check the TPM variables here and add them to
 		// the config in some way.
 		tc.TPMAIKPath = tpmaik
 		tc.TPMPCRs = tpmpcrs
 		tc.TPMDevice = tpmdev
-	case "pipe":
-		tc.HostChannelType = Pipe
-	case "file":
-		tc.HostChannelType = File
-	case "unix":
-		tc.HostChannelType = Unix
-	default:
-		tc.HostChannelType = NoChannel
 	}
 
 	if f != "" {
@@ -197,7 +165,7 @@ func (tc *Config) Merge(c Config) {
 		tc.HostType = c.HostType
 	}
 
-	if tc.HostChannelType == NoChannel || c.HostChannelType != NoChannel {
+	if tc.HostChannelType == "none" || c.HostChannelType != "none" {
 		tc.HostChannelType = c.HostChannelType
 	}
 

--- a/go/tao/linux_host_test.go
+++ b/go/tao/linux_host_test.go
@@ -74,6 +74,37 @@ func TestNewRootLinuxHost(t *testing.T) {
 	}
 }
 
+func TestNewStackedLinuxHostWithTao(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "test_new_stacked_linux_host")
+	if err != nil {
+		t.Errorf("ioutil.TempDir(\"\", \"test_new_stacked_linux_host\") = %v; want no error", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	tc := &Config{
+		HostType:        Stacked,
+		HostChannelType: "completely fake type",
+		HostSpec:        "completely fake spec",
+		HostedType:      NoHostedPrograms,
+	}
+
+	st, err := NewSoftTao("", nil)
+	if err != nil {
+		t.Errorf("NewSoftTao(\"\", nil) = %v; want no error", err)
+	}
+
+	f := func(string) (Tao, error) {
+		return st, nil
+	}
+	Register("completely fake type", f)
+
+	parentTao := ParentFromConfig(*tc)
+	tg := LiberalGuard
+	if _, err = NewStackedLinuxHost(tmpdir, &tg, parentTao, nil); err != nil {
+		t.Errorf("NewStackedLinuxHost(%q, %v, %v, nil) = %v", tmpdir, tg, parentTao, nil)
+	}
+}
+
 // Test the methods directly instead of testing them across a channel.
 
 var testChildLH = &LinuxHostChild{


### PR DESCRIPTION
This commit adds a Register call that takes a name and a function and
records them for later use a Tao channels. If the name is given in the
Tao config and there is a registered function with the same name, then
this function is used to generate the Tao host channel.