### PR TITLE
Fix the MAC in keys.go to not waste space.

### DIFF
--- a/go/run/scripts/domain_template.pb
+++ b/go/run/scripts/domain_template.pb
@@ -42,6 +42,7 @@ datalog_rules: "(forall P: MemberProgram(P) implies Authorized(P, \"Execute\"))"
 
 host_predicate_name: "TrustedHost"
 
+program_paths: "beacon"
 program_paths: "mixnet_router"
 program_paths: "demo_server"
 program_paths: "demo_client"

--- a/go/run/scripts/domain_template.pb
+++ b/go/run/scripts/domain_template.pb
@@ -42,7 +42,6 @@ datalog_rules: "(forall P: MemberProgram(P) implies Authorized(P, \"Execute\"))"
 
 host_predicate_name: "TrustedHost"
 
-program_paths: "beacon"
 program_paths: "mixnet_router"
 program_paths: "demo_server"
 program_paths: "demo_client"

--- a/go/tao/keys.go
+++ b/go/tao/keys.go
@@ -584,7 +584,8 @@ func (c *Crypter) Encrypt(data []byte) ([]byte, error) {
 	s.XORKeyStream(ciphertext[aes.BlockSize:], data)
 
 	mac := hmac.New(sha256.New, c.hmacKey)
-	m := mac.Sum(ciphertext)
+	mac.Write(ciphertext)
+	m := mac.Sum(nil)
 
 	ed := &EncryptedData{
 		Header:     ch,
@@ -615,7 +616,8 @@ func (c *Crypter) Decrypt(ciphertext []byte) ([]byte, error) {
 	copy(fullCiphertext[len(ed.Iv):], ed.Ciphertext)
 
 	mac := hmac.New(sha256.New, c.hmacKey)
-	m := mac.Sum(fullCiphertext)
+	mac.Write(fullCiphertext)
+	m := mac.Sum(nil)
 	if !hmac.Equal(m, ed.Mac) {
 		return nil, newError("bad HMAC")
 	}


### PR DESCRIPTION
The MAC field in EncryptedData in keys.proto was being computed on empty data due to a quirk in the Golang hmac API. This fixes it to use the hmac API correctly.