### PR TITLE
Small fixes

### DIFF
--- a/go/tao/domain.go
+++ b/go/tao/domain.go
@@ -87,6 +87,10 @@ func (cfg *DomainConfig) SetDefaults() {
 		cfg.TpmInfo.Pcrs = proto.String("17,18")
 	}
 
+	if cfg.Tpm2Info == nil {
+		cfg.Tpm2Info = &TPM2Details{}
+	}
+
 	if cfg.Tpm2Info.Tpm2Device == nil {
 		cfg.Tpm2Info.Tpm2Device = proto.String("/dev/tpm0")
 	}

--- a/go/tao/keys.go
+++ b/go/tao/keys.go
@@ -932,7 +932,7 @@ func NewSignedOnDiskPBEKeys(keyTypes KeyType, password []byte, path string, name
 		return nil, newError("the signing key must have a SigningKey and a Cert")
 	}
 
-	if keyTypes & ^Signing != 0 {
+	if keyTypes&Signing == 0 {
 		return nil, newError("can't sign a key that has no signer")
 	}
 


### PR DESCRIPTION
in domain.go: add check that domain template has TPM2Info to prevent NPE

in keys.go: 
in NewSignedOnDiskPBEKeys(), it seems that we want to sign keys that at least implement a Signer (not sure why but so it seems from the error message in line 936). Currently we sign keys that only implement a Signer.
